### PR TITLE
James 1623 - Hystrix wrapping for Mailbox and data-*

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -549,6 +549,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.james</groupId>
+            <artifactId>james-server-data-hystrix</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.james</groupId>
             <artifactId>james-server-data-jcr</artifactId>
             <scope>runtime</scope>
             <exclusions>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -461,6 +461,18 @@
         </dependency>
         <dependency>
             <groupId>org.apache.james</groupId>
+            <artifactId>apache-james-mailbox-hystrix</artifactId>
+            <scope>runtime</scope>
+            <version>0.6-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>mail</artifactId>
+                    <groupId>javax.mail</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.james</groupId>
             <artifactId>apache-james-mailbox-elasticsearch</artifactId>
             <scope>runtime</scope>
             <exclusions>

--- a/app/src/main/resources/domainlist-template.xml
+++ b/app/src/main/resources/domainlist-template.xml
@@ -45,14 +45,21 @@
 
 <!-- JPA implementation for DomainList -->
 <domainlist class="org.apache.james.domainlist.jpa.JPADomainList">
-   <autodetect>true</autodetect>
-   <autodetectIP>true</autodetectIP>
-   <defaultDomain>localhost</defaultDomain>
+    <!--
+            Hystrix is a Netfix library for handling errors in a distributed system.
+
+            It provides circuit breakers, fallback mechanisms, and live metrics for every command performed.
+        -->
+    <enableHystrix>false</enableHystrix>
+    <autodetect>true</autodetect>
+    <autodetectIP>true</autodetectIP>
+    <defaultDomain>localhost</defaultDomain>
 </domainlist>
 
 <!-- XML based implementation for DomainList -->
 <!-- 
 <domainlist class="org.apache.james.domainlist.xml.XMLDomainList">
+   <enableHystrix>false</enableHystrix>
    <domainnames>
        <domainname>localhost</domainname>
    </domainnames>

--- a/app/src/main/resources/indexer-template.xml
+++ b/app/src/main/resources/indexer-template.xml
@@ -30,4 +30,10 @@
    <!-- lazyIndex, elasticsearch -->
    <!--  -->
   <provider>lazyIndex</provider>
+    <!--
+    Hystrix is a Netfix library for handling errors in a distributed system.
+
+    It provides circuit breakers, fallback mechanisms, and live metrics for every command performed.
+    -->
+    <enableHystrix>false</enableHystrix>
 </indexer>

--- a/app/src/main/resources/mailbox-template.xml
+++ b/app/src/main/resources/mailbox-template.xml
@@ -31,4 +31,10 @@
    <!--  -->
    <!-- Be aware that maildir will only work on unix like operation systems! -->
    <provider>jpa</provider>
+    <!--
+    Hystrix is a Netfix library for handling errors in a distributed system.
+
+    It provides circuit breakers, fallback mechanisms, and live metrics for every command performed.
+    -->
+    <enableHystrix>false</enableHystrix>
 </mailbox>

--- a/app/src/main/resources/mailrepositorystore-template.xml
+++ b/app/src/main/resources/mailrepositorystore-template.xml
@@ -26,6 +26,12 @@
 <!-- See http://james.apache.org/server/3/config.html for usage -->
 
 <mailrepositorystore>
+    <!--
+    Hystrix is a Netfix library for handling errors in a distributed system.
+
+    It provides circuit breakers, fallback mechanisms, and live metrics for every command performed.
+    -->
+    <enableHystrix>false</enableHystrix>
 
    <mailrepositories>
 

--- a/app/src/main/resources/quota-template.xml
+++ b/app/src/main/resources/quota-template.xml
@@ -70,6 +70,12 @@
         quota synchronisation issues.
          -->
         <provider>none</provider>
+        <!--
+            Hystrix is a Netfix library for handling errors in a distributed system.
+
+            It provides circuit breakers, fallback mechanisms, and live metrics for every command performed.
+        -->
+        <enableHystrix>false</enableHystrix>
     </currentQuotaManager>
     <maxQuotaManager>
         <!--
@@ -105,6 +111,12 @@
             <value>10737418240</value>
         </maxStorage>
         -->
+        <!--
+            Hystrix is a Netfix library for handling errors in a distributed system.
+
+            It provides circuit breakers, fallback mechanisms, and live metrics for every command performed.
+        -->
+        <enableHystrix>false</enableHystrix>
     </maxQuotaManager>
     <quotaManager>
         <!--

--- a/app/src/main/resources/recipientrewritetable-template.xml
+++ b/app/src/main/resources/recipientrewritetable-template.xml
@@ -51,6 +51,12 @@
     
 <!-- The default table for storing James' RecipientRewriteTable mappings. -->
 <recipientrewritetable class="org.apache.james.rrt.jpa.JPARecipientRewriteTable">
+    <!--
+            Hystrix is a Netfix library for handling errors in a distributed system.
+
+            It provides circuit breakers, fallback mechanisms, and live metrics for every command performed.
+        -->
+    <enableHystrix>false</enableHystrix>
    <recursiveMapping>true</recursiveMapping>
    <mappingLimit>10</mappingLimit>
 </recipientrewritetable>

--- a/app/src/main/resources/usersrepository-template.xml
+++ b/app/src/main/resources/usersrepository-template.xml
@@ -36,6 +36,12 @@
   MD5, SHA-256, SHA-512, NONE
 -->
 <usersrepository name="LocalUsers" class="org.apache.james.user.jpa.JPAUsersRepository">
+    <!--
+            Hystrix is a Netfix library for handling errors in a distributed system.
+
+            It provides circuit breakers, fallback mechanisms, and live metrics for every command performed.
+        -->
+    <enableHystrix>false</enableHystrix>
     <algorithm>MD5</algorithm>
     <enableVirtualHosting>true</enableVirtualHosting>    
 </usersrepository>
@@ -54,6 +60,7 @@
 <!-- DEPRECATED: This implementation will get removed in the next release -->
 <!--
 <usersrepository name="LocalUsers" class="org.apache.james.user.file.UsersFileRepository">
+    <enableHystrix>false</enableHystrix>
     <destination URL="file://var/users/"/>
     <ignoreCase>true</ignoreCase>
     <enableAliases>true</enableAliases>
@@ -72,6 +79,7 @@
 <!--             Use JPAUsersRepository if you want to store the Users in a database -->
 <!-- 
 <usersrepository name="LocalUsers" class="org.apache.james.user.jdbc.JamesUsersJdbcRepository" destinationURL="db://maildb/users">
+    <enableHystrix>false</enableHystrix>
     <sqlFile>file://conf/sqlResources.xml</sqlFile>
     <ignoreCase>true</ignoreCase>
     <enableAliases>true</enableAliases>

--- a/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/ConfigurationBeanFactoryPostProcessor.java
+++ b/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/ConfigurationBeanFactoryPostProcessor.java
@@ -67,11 +67,12 @@ public class ConfigurationBeanFactoryPostProcessor implements BeanFactoryPostPro
 
                 // Get the configuration for the class
                 String repClass = config.getString("[@class]");
+                boolean enableHystrix = config.getBoolean("enableHystrix", false);
 
                 // Create the definition and register it
                 BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
                 BeanDefinition def = BeanDefinitionBuilder.genericBeanDefinition(repClass).getBeanDefinition();
-                registry.registerBeanDefinition(name, def);
+                registry.registerBeanDefinition("real-" + name, def);
 
                 String aliases = beans.get(name);
                 String[] aliasArray = aliases.split(",");
@@ -86,6 +87,11 @@ public class ConfigurationBeanFactoryPostProcessor implements BeanFactoryPostPro
                     }
                 }
 
+                if (enableHystrix) {
+                    registry.registerAlias("hystrix-" + name, name);
+                } else {
+                    registry.registerAlias("real-" + name, name);
+                }
             } catch (ConfigurationException e) {
                 throw new FatalBeanException("Unable to parse configuration for bean " + name, e);
             }

--- a/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/IndexerConfigurationBeanFactoryPostProcessor.java
+++ b/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/IndexerConfigurationBeanFactoryPostProcessor.java
@@ -46,6 +46,7 @@ public class IndexerConfigurationBeanFactoryPostProcessor implements BeanFactory
         try {
             HierarchicalConfiguration config = confProvider.getConfiguration("indexer");
             String provider = config.getString("provider", "lazyIndex");
+            boolean enableHystrix = config.getBoolean("enableHystrix", false);
 
             BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
             String indexer = null;
@@ -57,6 +58,12 @@ public class IndexerConfigurationBeanFactoryPostProcessor implements BeanFactory
 
             if (indexer == null)
                 throw new ConfigurationException("Indexer provider " + provider + " not supported!");
+
+            if (enableHystrix) {
+                registry.registerAlias(indexer, "wrapped-indexer");
+                indexer = "hystrix-indexer";
+            }
+
             registry.registerAlias(indexer, "indexer");
 
         } catch (ConfigurationException e) {

--- a/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/MailboxConfigurationBeanFactoryPostProcessor.java
+++ b/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/MailboxConfigurationBeanFactoryPostProcessor.java
@@ -46,6 +46,7 @@ public class MailboxConfigurationBeanFactoryPostProcessor implements BeanFactory
         try {
             HierarchicalConfiguration config = confProvider.getConfiguration("mailbox");
             String provider = config.getString("provider", "jpa");
+            boolean enableHystrix = config.getBoolean("enableHystrix", false);
 
             BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
             String mailbox = null;
@@ -79,6 +80,12 @@ public class MailboxConfigurationBeanFactoryPostProcessor implements BeanFactory
 
             if (mailbox == null)
                 throw new ConfigurationException("Mailboxmanager provider " + provider + " not supported!");
+
+            if (enableHystrix) {
+                registry.registerAlias(messageMapperFactory, "wrap-me-mailboxsessionfactory");
+                messageMapperFactory = "hystrix-mailboxsessionfactory";
+            }
+
             registry.registerAlias(mailbox, "mailboxmanager");
             registry.registerAlias(subscription, "subscriptionManager");
             registry.registerAlias(messageMapperFactory, "messageMapperFactory");

--- a/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/MailrepositoryConfigurationBeanFactoryPostProcessor.java
+++ b/container/spring/src/main/java/org/apache/james/container/spring/bean/factorypostprocessor/MailrepositoryConfigurationBeanFactoryPostProcessor.java
@@ -1,0 +1,49 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.container.spring.bean.factorypostprocessor;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.apache.james.container.spring.lifecycle.ConfigurationProvider;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.FatalBeanException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+
+public class MailrepositoryConfigurationBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
+
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        ConfigurationProvider confProvider = beanFactory.getBean(ConfigurationProvider.class);
+        try {
+            HierarchicalConfiguration config = confProvider.getConfiguration("mailrepositorystore");
+            boolean enableHystrix = config.getBoolean("enableHystrix", false);
+            BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
+            if (enableHystrix) {
+                registry.registerAlias("hystrix-mailrepositorystore", "mailrepositorystore");
+            } else {
+                registry.registerAlias("real-mailrepositorystore", "mailrepositorystore");
+            }
+        } catch (ConfigurationException e) {
+            throw new FatalBeanException("Unable to config the mail repository store", e);
+        }
+    }
+
+}

--- a/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
+++ b/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
@@ -41,6 +41,8 @@
 
     <import resource="classpath:META-INF/spring/loaders-context.xml"/>
 
+    <bean class="org.apache.james.container.spring.bean.factorypostprocessor.MailrepositoryConfigurationBeanFactoryPostProcessor"/>
+
     <!-- 
     ===========================================================================
        Authenticator

--- a/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
+++ b/container/spring/src/main/resources/META-INF/org/apache/james/spring-server.xml
@@ -117,6 +117,9 @@
 
     <import resource="classpath:META-INF/spring/spring-mailbox.xml"/>
 
+    <!-- Hystrix support-->
+    <import resource="classpath:META-INF/spring/mailbox-hystrix.xml"/>
+
     <!-- Quotas -->
     <bean class="org.apache.james.container.spring.bean.factorypostprocessor.QuotaBeanFactoryPostProcessor"/>
 

--- a/container/spring/src/main/resources/META-INF/spring/loaders-context.xml
+++ b/container/spring/src/main/resources/META-INF/spring/loaders-context.xml
@@ -32,6 +32,8 @@
     <bean id="logprovider" class="org.apache.james.container.spring.lifecycle.LogProviderImpl">
     </bean>
 
+    <import resource="classpath:META-INF/spring/hystrix-data.xml"/>
+
     <!--
       Configuration "Bean-Factory-Post-Processor"
         responsible to register beans from James specific configuration files
@@ -91,8 +93,14 @@
     </bean>
 
     <!-- Mail Repository Store "Bean-Factory" -->
-    <bean id="mailrepositorystore"
+    <bean id="real-mailrepositorystore"
           class="org.apache.james.container.spring.bean.factory.mailrepositorystore.MailRepositoryStoreBeanFactory"/>
+
+    <bean id="hystrix-mailrepositorystore"
+          class="org.apache.james.hystrix.mailrepository.HystrixMailRepositoryStore"
+          lazy-init="true">
+        <constructor-arg index="0" ref="real-mailrepositorystore"/>
+    </bean>
 
     <!--  Mailet and Matcher "Bean-Factory". -->
 

--- a/data/data-hystrix/pom.xml
+++ b/data/data-hystrix/pom.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>james-server</artifactId>
+        <groupId>org.apache.james</groupId>
+        <version>0.6-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>james-server-data-hystrix</artifactId>
+    <description>Hystrix is a metric system and fault tolerance system for large distributed systems</description>
+    <name>Apache James Server:: Data :: Hystrix</name>
+
+    <profiles>
+        <profile>
+            <id>noTest</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>disable-build-for-older-jdk</id>
+            <activation>
+                <jdk>(,1.8)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-jar</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>jar</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>test-jar</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-compile</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-testCompile</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-install-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-install</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-resources</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-testResources</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-site-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-descriptor</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>build-for-jdk-8</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.james</groupId>
+                    <artifactId>james-server-data-api</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>com.netflix.hystrix</groupId>
+                    <artifactId>hystrix-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>com.netflix.rxjava</groupId>
+                    <artifactId>rxjava-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.assertj</groupId>
+                    <artifactId>assertj-core</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>fully.qualified.MainClass</mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <source>1.8</source>
+                            <target>1.8</target>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/domainlist/HystrixDomainList.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/domainlist/HystrixDomainList.java
@@ -1,0 +1,88 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.domainlist;
+
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.domainlist.api.DomainListException;
+import org.apache.james.hystrix.domainlist.commands.AddDomainCommand;
+import org.apache.james.hystrix.domainlist.commands.ContainsDomainCommand;
+import org.apache.james.hystrix.domainlist.commands.GetDomainsCommand;
+import org.apache.james.hystrix.domainlist.commands.RemoveDomainCommand;
+
+/**
+ * Fallback policy is based on the default domain
+ */
+public class HystrixDomainList implements DomainList {
+
+    private final DomainList wrappedDomainList;
+
+    public HystrixDomainList(DomainList wrappedDomainList) {
+        this.wrappedDomainList = wrappedDomainList;
+    }
+
+    @Override
+    public String[] getDomains() throws DomainListException {
+        try {
+            return new GetDomainsCommand(wrappedDomainList).execute();
+        } catch(HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public boolean containsDomain(String domain) throws DomainListException {
+        try {
+            return new ContainsDomainCommand(wrappedDomainList, domain).execute();
+        } catch(HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void addDomain(String domain) throws DomainListException {
+        try {
+            new AddDomainCommand(wrappedDomainList, domain).execute();
+        } catch(HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void removeDomain(String domain) throws DomainListException {
+        try {
+            new RemoveDomainCommand(wrappedDomainList, domain).execute();
+        } catch(HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public String getDefaultDomain() throws DomainListException {
+        return wrappedDomainList.getDefaultDomain();
+    }
+
+    private DomainListException unboxException(HystrixBadRequestException e) {
+        if (e.getCause() instanceof DomainListException) {
+            return  (DomainListException) e.getCause();
+        }
+        throw new RuntimeException("HystrixBadRequestException wasn't containing MailboxException", e);
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/domainlist/commands/AddDomainCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/domainlist/commands/AddDomainCommand.java
@@ -1,0 +1,49 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.domainlist.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.domainlist.api.DomainListException;
+
+public class AddDomainCommand extends HystrixCommand<Void>{
+
+    private final DomainList wrappedDomainList;
+    private final String domain;
+
+    public AddDomainCommand(DomainList wrappedDomainList, String domain) {
+        super(HystrixCommandGroupKey.Factory.asKey("addDomains"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedDomainList = wrappedDomainList;
+        this.domain = domain;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedDomainList.addDomain(domain);
+            return null;
+        } catch(DomainListException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/domainlist/commands/ContainsDomainCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/domainlist/commands/ContainsDomainCommand.java
@@ -1,0 +1,63 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.domainlist.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.domainlist.api.DomainListException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ContainsDomainCommand extends HystrixCommand<Boolean>{
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContainsDomainCommand.class);
+
+    private final DomainList wrappedDomainList;
+    private final String domain;
+
+    public ContainsDomainCommand(DomainList wrappedDomainList, String domain) {
+        super(HystrixCommandGroupKey.Factory.asKey("containsDomains"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedDomainList = wrappedDomainList;
+        this.domain = domain;
+    }
+
+    @Override
+    protected Boolean run() throws Exception {
+        try {
+            return wrappedDomainList.containsDomain(domain);
+        } catch(DomainListException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+
+    @Override
+    protected Boolean getFallback() {
+        try {
+            LOGGER.warn("Domainlist fallback : serving default domain");
+            return wrappedDomainList.getDefaultDomain().equals(domain);
+        } catch (DomainListException e) {
+            LOGGER.error("Error while getting default domain on fallback", e);
+            throw new HystrixBadRequestException("Error in fallback", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/domainlist/commands/GetDomainsCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/domainlist/commands/GetDomainsCommand.java
@@ -1,0 +1,61 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.domainlist.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.domainlist.api.DomainListException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GetDomainsCommand extends HystrixCommand<String[]>{
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GetDomainsCommand.class);
+
+    private final DomainList wrappedDomainList;
+
+    public GetDomainsCommand(DomainList wrappedDomainList) {
+        super(HystrixCommandGroupKey.Factory.asKey("getDomains"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedDomainList = wrappedDomainList;
+    }
+
+    @Override
+    protected String[] run() throws Exception {
+        try {
+            return wrappedDomainList.getDomains();
+        } catch(DomainListException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+
+    @Override
+    protected String[] getFallback() {
+        try {
+            LOGGER.warn("Domainlist fallback : serving default domain");
+            return new String[]{wrappedDomainList.getDefaultDomain()};
+        } catch (DomainListException e) {
+            LOGGER.error("Error while getting default domain on fallback", e);
+            throw new HystrixBadRequestException("Error on fallback", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/domainlist/commands/RemoveDomainCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/domainlist/commands/RemoveDomainCommand.java
@@ -1,0 +1,49 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.domainlist.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.domainlist.api.DomainListException;
+
+public class RemoveDomainCommand extends HystrixCommand<Void> {
+
+    private final DomainList wrappedDomainList;
+    private final String domain;
+
+    public RemoveDomainCommand(DomainList wrappedDomainList, String domain) {
+        super(HystrixCommandGroupKey.Factory.asKey("removeDomains"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedDomainList = wrappedDomainList;
+        this.domain = domain;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedDomainList.removeDomain(domain);
+            return null;
+        } catch(DomainListException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/HystrixMailRepository.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/HystrixMailRepository.java
@@ -1,0 +1,117 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.mailrepository;
+
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.hystrix.mailrepository.commands.*;
+import org.apache.james.mailrepository.api.MailRepository;
+import org.apache.mailet.Mail;
+
+import javax.mail.MessagingException;
+import java.util.Collection;
+import java.util.Iterator;
+
+public class HystrixMailRepository implements MailRepository {
+
+    private final MailRepository wrappedMailRepository;
+
+    public HystrixMailRepository(MailRepository wrappedMailRepository) {
+        this.wrappedMailRepository = wrappedMailRepository;
+    }
+
+    @Override
+    public void store(Mail mc) throws MessagingException {
+        try {
+            new StoreCommand(wrappedMailRepository, mc).execute();
+        } catch(HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public Iterator<String> list() throws MessagingException {
+        try {
+            return new ListMailCommand(wrappedMailRepository).execute();
+        } catch(HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public Mail retrieve(String key) throws MessagingException {
+        try {
+            return new RetrieveMailCommand(wrappedMailRepository, key).execute();
+        } catch(HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void remove(Mail mail) throws MessagingException {
+        try {
+            new RemoveMailCommand(wrappedMailRepository, mail).execute();
+        } catch(HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void remove(Collection<Mail> mails) throws MessagingException {
+        try {
+            new RemoveMailsCommand(wrappedMailRepository, mails).execute();
+        } catch(HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void remove(String key) throws MessagingException {
+        try {
+            new RemoveMailKeyCommand(wrappedMailRepository, key).execute();
+        } catch(HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public boolean lock(String key) throws MessagingException {
+        try {
+            return new LockCommand(wrappedMailRepository, key).execute();
+        } catch(HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public boolean unlock(String key) throws MessagingException {
+        try {
+            return new UnlockCommand(wrappedMailRepository, key).execute();
+        } catch(HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    private MessagingException unboxException(HystrixBadRequestException e) {
+        if (e.getCause() instanceof MessagingException) {
+            return  (MessagingException) e.getCause();
+        }
+        throw new RuntimeException("HystrixBadRequestException wasn't containing MailboxException", e);
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/ListMailCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/ListMailCommand.java
@@ -1,0 +1,49 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.mailrepository.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.mailrepository.api.MailRepository;
+import org.apache.mailet.Mail;
+
+import javax.mail.MessagingException;
+import java.util.Iterator;
+
+public class ListMailCommand extends HystrixCommand<Iterator<String>> {
+
+    private final MailRepository wrappedMailRepository;
+
+    public ListMailCommand(MailRepository wrappedMailRepository) {
+        super(HystrixCommandGroupKey.Factory.asKey("listMail"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedMailRepository = wrappedMailRepository;
+    }
+
+    @Override
+    protected Iterator<String> run() throws Exception {
+        try {
+            return wrappedMailRepository.list();
+        } catch (MessagingException e) {
+            throw new HystrixBadRequestException("Can not perform request on underlying MailRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/LockCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/LockCommand.java
@@ -1,0 +1,50 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.mailrepository.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.mailrepository.api.MailRepository;
+import org.apache.mailet.Mail;
+
+import javax.mail.MessagingException;
+
+public class LockCommand extends HystrixCommand<Boolean> {
+
+    private final MailRepository wrappedMailRepository;
+    private final String key;
+
+    public LockCommand(MailRepository wrappedMailRepository, String key) {
+        super(HystrixCommandGroupKey.Factory.asKey("lockMail"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedMailRepository = wrappedMailRepository;
+        this.key = key;
+    }
+
+    @Override
+    protected Boolean run() throws Exception {
+        try {
+            return wrappedMailRepository.lock(key);
+        } catch (MessagingException e) {
+            throw new HystrixBadRequestException("Can not perform request on underlying MailRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/RemoveMailCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/RemoveMailCommand.java
@@ -1,0 +1,51 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.mailrepository.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.mailrepository.api.MailRepository;
+import org.apache.mailet.Mail;
+
+import javax.mail.MessagingException;
+
+public class RemoveMailCommand extends HystrixCommand<Void> {
+
+    private final MailRepository wrappedMailRepository;
+    private final Mail mail;
+
+    public RemoveMailCommand(MailRepository wrappedMailRepository, Mail mail) {
+        super(HystrixCommandGroupKey.Factory.asKey("removeMail"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedMailRepository = wrappedMailRepository;
+        this.mail = mail;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedMailRepository.remove(mail);
+            return null;
+        } catch (MessagingException e) {
+            throw new HystrixBadRequestException("Can not perform request on underlying MailRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/RemoveMailKeyCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/RemoveMailKeyCommand.java
@@ -1,0 +1,51 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.mailrepository.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.mailrepository.api.MailRepository;
+import org.apache.mailet.Mail;
+
+import javax.mail.MessagingException;
+
+public class RemoveMailKeyCommand extends HystrixCommand<Void> {
+
+    private final MailRepository wrappedMailRepository;
+    private final String key;
+
+    public RemoveMailKeyCommand(MailRepository wrappedMailRepository, String key) {
+        super(HystrixCommandGroupKey.Factory.asKey("removeMailKey"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedMailRepository = wrappedMailRepository;
+        this.key = key;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedMailRepository.remove(key);
+            return null;
+        } catch (MessagingException e) {
+            throw new HystrixBadRequestException("Can not perform request on underlying MailRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/RemoveMailsCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/RemoveMailsCommand.java
@@ -1,0 +1,52 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.mailrepository.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.mailrepository.api.MailRepository;
+import org.apache.mailet.Mail;
+
+import javax.mail.MessagingException;
+import java.util.Collection;
+
+public class RemoveMailsCommand extends HystrixCommand<Void> {
+
+    private final MailRepository wrappedMailRepository;
+    private final Collection<Mail> mails;
+
+    public RemoveMailsCommand(MailRepository wrappedMailRepository, Collection<Mail> mails) {
+        super(HystrixCommandGroupKey.Factory.asKey("removeMails"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedMailRepository = wrappedMailRepository;
+        this.mails = mails;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedMailRepository.remove(mails);
+            return null;
+        } catch (MessagingException e) {
+            throw new HystrixBadRequestException("Can not perform request on underlying MailRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/RetrieveMailCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/RetrieveMailCommand.java
@@ -1,0 +1,50 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.mailrepository.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.mailrepository.api.MailRepository;
+import org.apache.mailet.Mail;
+
+import javax.mail.MessagingException;
+
+public class RetrieveMailCommand extends HystrixCommand<Mail> {
+
+    private final MailRepository wrappedMailRepository;
+    private final String key;
+
+    public RetrieveMailCommand(MailRepository wrappedMailRepository, String key) {
+        super(HystrixCommandGroupKey.Factory.asKey("retrieveMail"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedMailRepository = wrappedMailRepository;
+        this.key = key;
+    }
+
+    @Override
+    protected Mail run() throws Exception {
+        try {
+            return wrappedMailRepository.retrieve(key);
+        } catch (MessagingException e) {
+            throw new HystrixBadRequestException("Can not perform request on underlying MailRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/StoreCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/StoreCommand.java
@@ -1,0 +1,51 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.mailrepository.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.mailrepository.api.MailRepository;
+import org.apache.mailet.Mail;
+
+import javax.mail.MessagingException;
+
+public class StoreCommand extends HystrixCommand<Void> {
+
+    private final MailRepository wrappedMailRepository;
+    private final Mail mail;
+
+    public StoreCommand(MailRepository wrappedMailRepository, Mail mail) {
+        super(HystrixCommandGroupKey.Factory.asKey("storeMail"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedMailRepository = wrappedMailRepository;
+        this.mail = mail;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedMailRepository.store(mail);
+            return null;
+        } catch (MessagingException e) {
+            throw new HystrixBadRequestException("Can not perform request on underlying MailRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/UnlockCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/mailrepository/commands/UnlockCommand.java
@@ -1,0 +1,50 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.mailrepository.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.mailrepository.api.MailRepository;
+import org.apache.mailet.Mail;
+
+import javax.mail.MessagingException;
+
+public class UnlockCommand extends HystrixCommand<Boolean> {
+
+    private final MailRepository wrappedMailRepository;
+    private final String key;
+
+    public UnlockCommand(MailRepository wrappedMailRepository, String key) {
+        super(HystrixCommandGroupKey.Factory.asKey("unlockMail"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedMailRepository = wrappedMailRepository;
+        this.key = key;
+    }
+
+    @Override
+    protected Boolean run() throws Exception {
+        try {
+            return wrappedMailRepository.unlock(key);
+        } catch (MessagingException e) {
+            throw new HystrixBadRequestException("Can not perform request on underlying MailRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/HystrixRecipientRewriteTable.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/HystrixRecipientRewriteTable.java
@@ -1,0 +1,161 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.rrt;
+
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.hystrix.rrt.commands.*;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class HystrixRecipientRewriteTable implements RecipientRewriteTable {
+
+    private final RecipientRewriteTable recipientRewriteTable;
+
+    public HystrixRecipientRewriteTable(RecipientRewriteTable recipientRewriteTable) {
+        this.recipientRewriteTable = recipientRewriteTable;
+    }
+
+    @Override
+    public Collection<String> getMappings(String user, String domain) throws ErrorMappingException, RecipientRewriteTableException {
+        try {
+            return new GetMappingsCommand(recipientRewriteTable, user, domain).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void addRegexMapping(String user, String domain, String regex) throws RecipientRewriteTableException {
+        try {
+            new AddRegexMappingCommand(recipientRewriteTable, user, domain, regex).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void removeRegexMapping(String user, String domain, String regex) throws RecipientRewriteTableException {
+        try {
+            new RemoveRegexMappingCommand(recipientRewriteTable, user, domain, regex).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void addAddressMapping(String user, String domain, String address) throws RecipientRewriteTableException {
+        try {
+            new AddAddressMappingCommand(recipientRewriteTable, user, domain, address).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void removeAddressMapping(String user, String domain, String address) throws RecipientRewriteTableException {
+        try {
+            new RemoveAddressMappingCommand(recipientRewriteTable, user, domain, address).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void addErrorMapping(String user, String domain, String error) throws RecipientRewriteTableException {
+        try {
+            new AddErrorMappingCommand(recipientRewriteTable, user, domain, error).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void removeErrorMapping(String user, String domain, String error) throws RecipientRewriteTableException {
+        try {
+            new RemoveErrorMappingCommand(recipientRewriteTable, user, domain, error).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public Collection<String> getUserDomainMappings(String user, String domain) throws RecipientRewriteTableException {
+        try {
+            return new GetUserDomainMappingsCommand(recipientRewriteTable, user, domain).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void addMapping(String user, String domain, String mapping) throws RecipientRewriteTableException {
+        try {
+            new AddMappingCommand(recipientRewriteTable, user, domain, mapping).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void removeMapping(String user, String domain, String mapping) throws RecipientRewriteTableException {
+        try {
+            new RemoveMappingComand(recipientRewriteTable, user, domain, mapping).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public Map<String, Collection<String>> getAllMappings() throws RecipientRewriteTableException {
+        try {
+            return new GetAllMappingsCommand(recipientRewriteTable).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void addAliasDomainMapping(String aliasDomain, String realDomain) throws RecipientRewriteTableException {
+        try {
+            new AddAliasDomainMappingCommand(recipientRewriteTable, aliasDomain, realDomain).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void removeAliasDomainMapping(String aliasDomain, String realDomain) throws RecipientRewriteTableException {
+        try {
+            new RemoveAliasMappingCommand(recipientRewriteTable, aliasDomain, realDomain).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    private RecipientRewriteTableException unboxException(HystrixBadRequestException e) {
+        if (e.getCause() instanceof RecipientRewriteTableException) {
+            return  (RecipientRewriteTableException) e.getCause();
+        }
+        throw new RuntimeException("HystrixBadRequestException wasn't containing MailboxException", e);
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/AddAddressMappingCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/AddAddressMappingCommand.java
@@ -1,0 +1,56 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.rrt.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+
+public class AddAddressMappingCommand extends HystrixCommand<Void>{
+
+    private final RecipientRewriteTable wrappedRecipientRewriteTable;
+    private final String user;
+    private final String domain;
+    private final String address;
+
+    public AddAddressMappingCommand(RecipientRewriteTable wrappedRecipientRewriteTable,
+                                    String user,
+                                    String domain,
+                                    String address) {
+        super(HystrixCommandGroupKey.Factory.asKey("addAddressMappings"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedRecipientRewriteTable = wrappedRecipientRewriteTable;
+        this.user = user;
+        this.domain = domain;
+        this.address = address;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedRecipientRewriteTable.addAddressMapping(user, domain, address);
+            return null;
+        } catch(RecipientRewriteTableException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/AddAliasDomainMappingCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/AddAliasDomainMappingCommand.java
@@ -1,0 +1,53 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.rrt.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+
+public class AddAliasDomainMappingCommand extends HystrixCommand<Void>{
+
+    private final RecipientRewriteTable wrappedRecipientRewriteTable;
+    private final String aliasDomain;
+    private final String realDomain;
+
+    public AddAliasDomainMappingCommand(RecipientRewriteTable wrappedRecipientRewriteTable,
+                                        String aliasDomain,
+                                        String realDomain) {
+        super(HystrixCommandGroupKey.Factory.asKey("addAliasMappings"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedRecipientRewriteTable = wrappedRecipientRewriteTable;
+        this.aliasDomain = aliasDomain;
+        this.realDomain = realDomain;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedRecipientRewriteTable.addAliasDomainMapping(aliasDomain, realDomain);
+            return null;
+        } catch(RecipientRewriteTableException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/AddErrorMappingCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/AddErrorMappingCommand.java
@@ -1,0 +1,56 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.rrt.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+
+public class AddErrorMappingCommand extends HystrixCommand<Void>{
+
+    private final RecipientRewriteTable wrappedRecipientRewriteTable;
+    private final String user;
+    private final String domain;
+    private final String error;
+
+    public AddErrorMappingCommand(RecipientRewriteTable wrappedRecipientRewriteTable,
+                                  String user,
+                                  String domain,
+                                  String error) {
+        super(HystrixCommandGroupKey.Factory.asKey("addErrorMappings"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedRecipientRewriteTable = wrappedRecipientRewriteTable;
+        this.user = user;
+        this.domain = domain;
+        this.error = error;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedRecipientRewriteTable.addErrorMapping(user, domain, error);
+            return null;
+        } catch(RecipientRewriteTableException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/AddMappingCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/AddMappingCommand.java
@@ -1,0 +1,56 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.rrt.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+
+public class AddMappingCommand extends HystrixCommand<Void>{
+
+    private final RecipientRewriteTable wrappedRecipientRewriteTable;
+    private final String user;
+    private final String domain;
+    private final String mapping;
+
+    public AddMappingCommand(RecipientRewriteTable wrappedRecipientRewriteTable,
+                             String user,
+                             String domain,
+                             String mapping) {
+        super(HystrixCommandGroupKey.Factory.asKey("addMappings"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedRecipientRewriteTable = wrappedRecipientRewriteTable;
+        this.user = user;
+        this.domain = domain;
+        this.mapping = mapping;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedRecipientRewriteTable.addMapping(user, domain, mapping);
+            return null;
+        } catch(RecipientRewriteTableException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/AddRegexMappingCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/AddRegexMappingCommand.java
@@ -1,0 +1,56 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.rrt.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+
+public class AddRegexMappingCommand extends HystrixCommand<Void>{
+
+    private final RecipientRewriteTable wrappedRecipientRewriteTable;
+    private final String user;
+    private final String domain;
+    private final String regex;
+
+    public AddRegexMappingCommand(RecipientRewriteTable wrappedRecipientRewriteTable,
+                                  String user,
+                                  String domain,
+                                  String regex) {
+        super(HystrixCommandGroupKey.Factory.asKey("addRegexMappings"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedRecipientRewriteTable = wrappedRecipientRewriteTable;
+        this.user = user;
+        this.domain = domain;
+        this.regex = regex;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedRecipientRewriteTable.addRegexMapping(user, domain, regex);
+            return null;
+        } catch(RecipientRewriteTableException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/GetAllMappingsCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/GetAllMappingsCommand.java
@@ -1,0 +1,60 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.rrt.commands;
+
+import com.google.common.collect.Maps;
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class GetAllMappingsCommand extends HystrixCommand<Map<String, Collection<String>>>{
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(GetAllMappingsCommand.class);
+
+    private final RecipientRewriteTable wrappedRecipientRewriteTable;
+
+    public GetAllMappingsCommand(RecipientRewriteTable wrappedRecipientRewriteTable) {
+        super(HystrixCommandGroupKey.Factory.asKey("getAllMappings"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedRecipientRewriteTable = wrappedRecipientRewriteTable;
+    }
+
+    @Override
+    protected Map<String, Collection<String>> run() throws Exception {
+        try {
+            return wrappedRecipientRewriteTable.getAllMappings();
+        } catch(RecipientRewriteTableException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+
+    @Override
+    protected Map<String, Collection<String>> getFallback() {
+        LOGGER.warn("Failed to load All mappings from backend. Serving empty mappings instead.");
+        return Maps.newHashMap();
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/GetMappingsCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/GetMappingsCommand.java
@@ -1,0 +1,63 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.rrt.commands;
+
+import com.google.common.collect.Lists;
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+public class GetMappingsCommand extends HystrixCommand<Collection<String>>{
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(GetMappingsCommand.class);
+
+    private final RecipientRewriteTable wrappedRecipientRewriteTable;
+    private final String user;
+    private final String domain;
+
+    public GetMappingsCommand(RecipientRewriteTable wrappedRecipientRewriteTable, String user, String domain) {
+        super(HystrixCommandGroupKey.Factory.asKey("getMappings"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedRecipientRewriteTable = wrappedRecipientRewriteTable;
+        this.user = user;
+        this.domain = domain;
+    }
+
+    @Override
+    protected Collection<String> run() throws Exception {
+        try {
+            return wrappedRecipientRewriteTable.getMappings(user, domain);
+        } catch(RecipientRewriteTableException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+
+    @Override
+    protected Collection<String> getFallback() {
+        LOGGER.warn("Failed to load " + user + "'s mappings for " + domain + " from backend. Serving empty mappings instead.");
+        return Lists.newArrayList();
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/GetUserDomainMappingsCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/GetUserDomainMappingsCommand.java
@@ -1,0 +1,63 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.rrt.commands;
+
+import com.google.common.collect.Lists;
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+public class GetUserDomainMappingsCommand extends HystrixCommand<Collection<String>>{
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(GetUserDomainMappingsCommand.class);
+
+    private final RecipientRewriteTable wrappedRecipientRewriteTable;
+    private final String user;
+    private final String domain;
+
+    public GetUserDomainMappingsCommand(RecipientRewriteTable wrappedRecipientRewriteTable, String user, String domain) {
+        super(HystrixCommandGroupKey.Factory.asKey("getUserDomainMappings"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedRecipientRewriteTable = wrappedRecipientRewriteTable;
+        this.user = user;
+        this.domain = domain;
+    }
+
+    @Override
+    protected Collection<String> run() throws Exception {
+        try {
+            return wrappedRecipientRewriteTable.getUserDomainMappings(user, domain);
+        } catch(RecipientRewriteTableException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+
+    @Override
+    protected Collection<String> getFallback() {
+        LOGGER.warn("Failed to load " + user + "'s user domain mappings for " + domain + " from backend. Serving empty mappings instead.");
+        return Lists.newArrayList();
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/RemoveAddressMappingCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/RemoveAddressMappingCommand.java
@@ -1,0 +1,58 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.rrt.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+
+import java.util.Collection;
+
+public class RemoveAddressMappingCommand extends HystrixCommand<Collection<String>>{
+
+    private final RecipientRewriteTable wrappedRecipientRewriteTable;
+    private final String user;
+    private final String domain;
+    private final String address;
+
+    public RemoveAddressMappingCommand(RecipientRewriteTable wrappedRecipientRewriteTable,
+                                       String user,
+                                       String domain,
+                                       String address) {
+        super(HystrixCommandGroupKey.Factory.asKey("removeAddressMappings"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedRecipientRewriteTable = wrappedRecipientRewriteTable;
+        this.user = user;
+        this.domain = domain;
+        this.address = address;
+    }
+
+    @Override
+    protected Collection<String> run() throws Exception {
+        try {
+            wrappedRecipientRewriteTable.removeAddressMapping(user, domain, address);
+            return null;
+        } catch(RecipientRewriteTableException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/RemoveAliasMappingCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/RemoveAliasMappingCommand.java
@@ -1,0 +1,51 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.rrt.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+
+public class RemoveAliasMappingCommand extends HystrixCommand<Void>{
+
+    private final RecipientRewriteTable wrappedRecipientRewriteTable;
+    private final String aliasDomain;
+    private final String realDomain;
+
+    public RemoveAliasMappingCommand(RecipientRewriteTable wrappedRecipientRewriteTable, String aliasDomain, String realDomain) {
+        super(HystrixCommandGroupKey.Factory.asKey("removeAliasMappings"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedRecipientRewriteTable = wrappedRecipientRewriteTable;
+        this.aliasDomain = aliasDomain;
+        this.realDomain = realDomain;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedRecipientRewriteTable.removeAliasDomainMapping(aliasDomain, realDomain);
+            return null;
+        } catch(RecipientRewriteTableException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/RemoveErrorMappingCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/RemoveErrorMappingCommand.java
@@ -1,0 +1,56 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.rrt.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+
+public class RemoveErrorMappingCommand extends HystrixCommand<Void>{
+
+    private final RecipientRewriteTable wrappedRecipientRewriteTable;
+    private final String user;
+    private final String domain;
+    private final String error;
+
+    public RemoveErrorMappingCommand(RecipientRewriteTable wrappedRecipientRewriteTable,
+                                     String user,
+                                     String domain,
+                                     String error) {
+        super(HystrixCommandGroupKey.Factory.asKey("removeErrorMappings"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedRecipientRewriteTable = wrappedRecipientRewriteTable;
+        this.user = user;
+        this.domain = domain;
+        this.error = error;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedRecipientRewriteTable.removeErrorMapping(user, domain, error);
+            return null;
+        } catch(RecipientRewriteTableException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/RemoveMappingComand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/RemoveMappingComand.java
@@ -1,0 +1,56 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.rrt.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+
+public class RemoveMappingComand extends HystrixCommand<Void>{
+
+    private final RecipientRewriteTable wrappedRecipientRewriteTable;
+    private final String user;
+    private final String domain;
+    private final String mapping;
+
+    public RemoveMappingComand(RecipientRewriteTable wrappedRecipientRewriteTable,
+                               String user,
+                               String domain,
+                               String mapping) {
+        super(HystrixCommandGroupKey.Factory.asKey("removeMappings"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedRecipientRewriteTable = wrappedRecipientRewriteTable;
+        this.user = user;
+        this.domain = domain;
+        this.mapping = mapping;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedRecipientRewriteTable.removeMapping(user, domain, mapping);
+            return null;
+        } catch(RecipientRewriteTableException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/RemoveRegexMappingCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/rrt/commands/RemoveRegexMappingCommand.java
@@ -1,0 +1,58 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.rrt.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.rrt.api.RecipientRewriteTable;
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+
+import java.util.Collection;
+
+public class RemoveRegexMappingCommand extends HystrixCommand<Void>{
+
+    private final RecipientRewriteTable wrappedRecipientRewriteTable;
+    private final String user;
+    private final String domain;
+    private final String regex;
+
+    public RemoveRegexMappingCommand(RecipientRewriteTable wrappedRecipientRewriteTable,
+                                     String user,
+                                     String domain,
+                                     String regex) {
+        super(HystrixCommandGroupKey.Factory.asKey("removeRegexMappings"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedRecipientRewriteTable = wrappedRecipientRewriteTable;
+        this.user = user;
+        this.domain = domain;
+        this.regex = regex;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedRecipientRewriteTable.removeRegexMapping(user, domain, regex);
+            return null;
+        } catch(RecipientRewriteTableException e) {
+            throw new HystrixBadRequestException("Error while using domain list", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/HystrixUsersRepository.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/HystrixUsersRepository.java
@@ -1,0 +1,121 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.users;
+
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.hystrix.users.commands.*;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.api.UsersRepositoryException;
+import org.apache.james.user.api.model.User;
+
+import java.util.Iterator;
+
+public class HystrixUsersRepository implements UsersRepository {
+
+    private final UsersRepository wrappedUsersRepository;
+
+    public HystrixUsersRepository(UsersRepository wrappedUsersRepository) {
+        this.wrappedUsersRepository = wrappedUsersRepository;
+    }
+
+    @Override
+    public void addUser(String username, String password) throws UsersRepositoryException {
+        try {
+            new AddUserCommand(wrappedUsersRepository, username, password).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public User getUserByName(String name) throws UsersRepositoryException {
+        try {
+            return new GetUserByNameCommand(wrappedUsersRepository, name).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void updateUser(User user) throws UsersRepositoryException {
+        try {
+            new UpdateUserCommand(wrappedUsersRepository, user).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public void removeUser(String name) throws UsersRepositoryException {
+        try {
+            new RemoveUserCommand(wrappedUsersRepository, name).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public boolean contains(String name) throws UsersRepositoryException {
+        try {
+            return new ContainsCommand(wrappedUsersRepository, name).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public boolean test(String name, String password) throws UsersRepositoryException {
+        try {
+            return new TestCommand(wrappedUsersRepository, name, password).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public int countUsers() throws UsersRepositoryException {
+        try {
+            return new CountUsersCommand(wrappedUsersRepository).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public Iterator<String> list() throws UsersRepositoryException {
+        try {
+            return new ListCommand(wrappedUsersRepository).execute();
+        } catch (HystrixBadRequestException e) {
+            throw unboxException(e);
+        }
+    }
+
+    @Override
+    public boolean supportVirtualHosting() throws UsersRepositoryException {
+        return wrappedUsersRepository.supportVirtualHosting();
+    }
+
+    private UsersRepositoryException unboxException(HystrixBadRequestException e) {
+        if (e.getCause() instanceof UsersRepositoryException) {
+            return  (UsersRepositoryException) e.getCause();
+        }
+        throw new RuntimeException("HystrixBadRequestException wasn't containing MailboxException", e);
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/AddUserCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/AddUserCommand.java
@@ -1,0 +1,51 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.users.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.api.UsersRepositoryException;
+
+public class AddUserCommand extends HystrixCommand<Void>{
+
+    private final UsersRepository wrappedUsersRepository;
+    private final String user;
+    private final String password;
+
+    public AddUserCommand(UsersRepository usersRepository, String user, String password) {
+        super(HystrixCommandGroupKey.Factory.asKey("addUser"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.user = user;
+        this.password = password;
+        this.wrappedUsersRepository = usersRepository;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedUsersRepository.addUser(user, password);
+            return null;
+        } catch (UsersRepositoryException e) {
+            throw new HystrixBadRequestException("Error while running UsersRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/ContainsCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/ContainsCommand.java
@@ -1,0 +1,48 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.users.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.api.UsersRepositoryException;
+
+public class ContainsCommand extends HystrixCommand<Boolean>{
+
+    private final UsersRepository wrappedUsersRepository;
+    private final String user;
+
+    public ContainsCommand(UsersRepository usersRepository, String user) {
+        super(HystrixCommandGroupKey.Factory.asKey("containsUser"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.user = user;
+        this.wrappedUsersRepository = usersRepository;
+    }
+
+    @Override
+    protected Boolean run() throws Exception {
+        try {
+            return wrappedUsersRepository.contains(user);
+        } catch (UsersRepositoryException e) {
+            throw new HystrixBadRequestException("Error while running UsersRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/CountUsersCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/CountUsersCommand.java
@@ -1,0 +1,46 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.users.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.api.UsersRepositoryException;
+
+public class CountUsersCommand extends HystrixCommand<Integer>{
+
+    private final UsersRepository wrappedUsersRepository;
+
+    public CountUsersCommand(UsersRepository usersRepository) {
+        super(HystrixCommandGroupKey.Factory.asKey("countUsers"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedUsersRepository = usersRepository;
+    }
+
+    @Override
+    protected Integer run() throws Exception {
+        try {
+            return wrappedUsersRepository.countUsers();
+        } catch (UsersRepositoryException e) {
+            throw new HystrixBadRequestException("Error while running UsersRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/GetUserByNameCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/GetUserByNameCommand.java
@@ -1,0 +1,49 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.users.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.api.UsersRepositoryException;
+import org.apache.james.user.api.model.User;
+
+public class GetUserByNameCommand extends HystrixCommand<User>{
+
+    private final UsersRepository wrappedUsersRepository;
+    private final String user;
+
+    public GetUserByNameCommand(UsersRepository usersRepository, String user) {
+        super(HystrixCommandGroupKey.Factory.asKey("getUserByName"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.user = user;
+        this.wrappedUsersRepository = usersRepository;
+    }
+
+    @Override
+    protected User run() throws Exception {
+        try {
+            return wrappedUsersRepository.getUserByName(user);
+        } catch (UsersRepositoryException e) {
+            throw new HystrixBadRequestException("Error while running UsersRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/ListCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/ListCommand.java
@@ -1,0 +1,49 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.users.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.api.UsersRepositoryException;
+
+import java.util.Iterator;
+
+public class ListCommand extends HystrixCommand<Iterator<String>>{
+
+    private final UsersRepository wrappedUsersRepository;
+
+    public ListCommand(UsersRepository usersRepository) {
+        super(HystrixCommandGroupKey.Factory.asKey("listUsers"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.wrappedUsersRepository = usersRepository;
+    }
+
+    @Override
+    protected Iterator<String> run() throws Exception {
+        try {
+            wrappedUsersRepository.list();
+            return null;
+        } catch (UsersRepositoryException e) {
+            throw new HystrixBadRequestException("Error while running UsersRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/RemoveUserCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/RemoveUserCommand.java
@@ -1,0 +1,49 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.users.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.api.UsersRepositoryException;
+
+public class RemoveUserCommand extends HystrixCommand<Void>{
+
+    private final UsersRepository wrappedUsersRepository;
+    private final String user;
+
+    public RemoveUserCommand(UsersRepository usersRepository, String user) {
+        super(HystrixCommandGroupKey.Factory.asKey("addUser"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.user = user;
+        this.wrappedUsersRepository = usersRepository;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedUsersRepository.removeUser(user);
+            return null;
+        } catch (UsersRepositoryException e) {
+            throw new HystrixBadRequestException("Error while running UsersRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/TestCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/TestCommand.java
@@ -1,0 +1,50 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.users.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.api.UsersRepositoryException;
+
+public class TestCommand extends HystrixCommand<Boolean>{
+
+    private final UsersRepository wrappedUsersRepository;
+    private final String user;
+    private final String password;
+
+    public TestCommand(UsersRepository usersRepository, String user, String password) {
+        super(HystrixCommandGroupKey.Factory.asKey("testUserAuthentication"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.user = user;
+        this.password = password;
+        this.wrappedUsersRepository = usersRepository;
+    }
+
+    @Override
+    protected Boolean run() throws Exception {
+        try {
+            return wrappedUsersRepository.test(user, password);
+        } catch (UsersRepositoryException e) {
+            throw new HystrixBadRequestException("Error while running UsersRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/UpdateUserCommand.java
+++ b/data/data-hystrix/src/main/java/org/apache/james/hystrix/users/commands/UpdateUserCommand.java
@@ -1,0 +1,50 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.users.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.api.UsersRepositoryException;
+import org.apache.james.user.api.model.User;
+
+public class UpdateUserCommand extends HystrixCommand<Void>{
+
+    private final UsersRepository wrappedUsersRepository;
+    private final User user;
+
+    public UpdateUserCommand(UsersRepository usersRepository, User user) {
+        super(HystrixCommandGroupKey.Factory.asKey("updateUser"), HystrixThreadPoolKey.Factory.asKey("dataStorage"));
+        this.user = user;
+        this.wrappedUsersRepository = usersRepository;
+    }
+
+    @Override
+    protected Void run() throws Exception {
+        try {
+            wrappedUsersRepository.updateUser(user);
+            return null;
+        } catch (UsersRepositoryException e) {
+            throw new HystrixBadRequestException("Error while running UsersRepository", e);
+        }
+    }
+}

--- a/data/data-hystrix/src/main/resources/META-INF/spring/hystrix-data.xml
+++ b/data/data-hystrix/src/main/resources/META-INF/spring/hystrix-data.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:camel="http://camel.apache.org/schema/spring"
+       xsi:schemaLocation="
+          http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+          http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+
+    <bean id="hystrix-domainlist" class="org.apache.james.hystrix.domainlist.HystrixDomainList" lazy-init="true">
+        <constructor-arg index="0" ref="real-domainlist"/>
+    </bean>
+
+    <bean id="hystrix-usersrepository" class="org.apache.james.hystrix.users.HystrixUsersRepository" lazy-init="true">
+        <constructor-arg index="0" ref="real-usersrepository"/>
+    </bean>
+
+    <bean id="hystrix-recipientrewritetable" class="org.apache.james.hystrix.rrt.HystrixRecipientRewriteTable" lazy-init="true">
+        <constructor-arg index="0" ref="real-recipientrewritetable"/>
+    </bean>
+
+</beans>

--- a/data/data-hystrix/src/test/java/org/apache/james/hystrix/domainlist/HystrixDomainListTest.java
+++ b/data/data-hystrix/src/test/java/org/apache/james/hystrix/domainlist/HystrixDomainListTest.java
@@ -1,0 +1,97 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.domainlist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.domainlist.api.DomainListException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HystrixDomainListTest {
+
+    public static final String DOMAIN = "domain";
+    private DomainList mockedDomainList;
+    private DomainList testee;
+
+    @Before
+    public void setUp() {
+        mockedDomainList = mock(DomainList.class);
+        testee = new HystrixDomainList(mockedDomainList);
+    }
+
+    @Test
+    public void addDomainShouldCallUnderlyingDomainList() throws Exception {
+        testee.addDomain(DOMAIN);
+        verify(mockedDomainList).addDomain(DOMAIN);
+    }
+
+    @Test
+    public void containsDomainShouldCallUnderlyingDomainList() throws Exception {
+        testee.containsDomain(DOMAIN);
+        verify(mockedDomainList).containsDomain(DOMAIN);
+    }
+
+    @Test
+    public void getDefaultDomainShouldCallUnderlyingDomainList() throws Exception {
+        testee.getDefaultDomain();
+        verify(mockedDomainList).getDefaultDomain();
+    }
+
+    @Test
+    public void getDomainsShouldCallUnderlyingDomainList() throws Exception {
+        testee.getDomains();
+        verify(mockedDomainList).getDomains();
+    }
+
+    @Test
+    public void removeDomainShouldCallUnderlyingDomainList() throws Exception {
+        testee.removeDomain(DOMAIN);
+        verify(mockedDomainList).removeDomain(DOMAIN);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void getDomainShouldFallback() throws Exception {
+        when(mockedDomainList.getDomains()).thenThrow(RuntimeException.class);
+        when(mockedDomainList.getDefaultDomain()).thenAnswer(invocationOnMock -> DOMAIN);
+        assertThat(testee.getDomains()).containsExactly(DOMAIN);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void containsDomainShouldFallback() throws Exception {
+        when(mockedDomainList.containsDomain(DOMAIN)).thenThrow(RuntimeException.class);
+        when(mockedDomainList.getDefaultDomain()).thenAnswer(invocationOnMock -> DOMAIN);
+        assertThat(testee.containsDomain(DOMAIN)).isTrue();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = DomainListException.class)
+    public void domainListExceptionShouldBePropagated() throws Exception {
+        when(mockedDomainList.containsDomain(DOMAIN)).thenThrow(DomainListException.class);
+        testee.containsDomain(DOMAIN);
+    }
+}

--- a/data/data-hystrix/src/test/java/org/apache/james/hystrix/mailrepository/HystrixMailRepositoryTest.java
+++ b/data/data-hystrix/src/test/java/org/apache/james/hystrix/mailrepository/HystrixMailRepositoryTest.java
@@ -1,0 +1,104 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.mailrepository;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.james.mailrepository.api.MailRepository;
+import org.apache.mailet.Mail;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.mail.MessagingException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class HystrixMailRepositoryTest {
+
+    private static final String KEY = "key";
+
+    private MailRepository mockedMailRepository;
+    private MailRepository testee;
+
+    @Before
+    public void setUp() {
+        mockedMailRepository = mock(MailRepository.class);
+        testee = new HystrixMailRepository(mockedMailRepository);
+    }
+
+    @Test
+    public void listShouldCallUnderlyingMailRepository() throws Exception {
+        testee.list();
+        verify(mockedMailRepository).list();
+    }
+
+    @Test
+    public void lockShouldCallUnderlyingMailRepository() throws Exception {
+        testee.lock(KEY);
+        verify(mockedMailRepository).lock(KEY);
+    }
+
+    @Test
+    public void removeShouldCallUnderlyingMailRepository() throws Exception {
+        testee.remove((Mail) null);
+        verify(mockedMailRepository).remove((Mail) null);
+    }
+
+    @Test
+    public void removeStringShouldCallUnderlyingMailRepository() throws Exception {
+        testee.remove(KEY);
+        verify(mockedMailRepository).remove(KEY);
+    }
+
+    @Test
+    public void removeListShouldCallUnderlyingMailRepository() throws Exception {
+        List<Mail> list = new ArrayList<>();
+        testee.remove(list);
+        verify(mockedMailRepository).remove(list);
+    }
+
+    @Test
+    public void retrieveShouldCallUnderlyingMailRepository() throws Exception {
+        testee.retrieve(KEY);
+        verify(mockedMailRepository).retrieve(KEY);
+    }
+
+    @Test
+    public void storeShouldCallUnderlyingMailRepository() throws Exception {
+        testee.store(null);
+        verify(mockedMailRepository).store(null);
+    }
+
+    @Test
+    public void unlockShouldCallUnderlyingMailRepository() throws Exception {
+        testee.unlock(KEY);
+        verify(mockedMailRepository).unlock(KEY);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = MessagingException.class)
+    public void messagingExceptionShouldBePropagated() throws Exception {
+        when(mockedMailRepository.retrieve(KEY)).thenThrow(MessagingException.class);
+        testee.retrieve(KEY);
+    }
+
+}

--- a/data/data-hystrix/src/test/java/org/apache/james/hystrix/rrt/HystrixRecipientRewriteTableTest.java
+++ b/data/data-hystrix/src/test/java/org/apache/james/hystrix/rrt/HystrixRecipientRewriteTableTest.java
@@ -1,0 +1,156 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.rrt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.james.rrt.api.RecipientRewriteTableException;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.james.rrt.api.RecipientRewriteTable;
+
+public class HystrixRecipientRewriteTableTest {
+
+    private static final String USER = "user";
+    private static final String DOMAIN = "domain";
+    private static final String ADDRESS = "address";
+    private static final String REAL_DOMAIN = "other";
+    private static final String ERROR = "error";
+    private static final String MAPPING = "mapping";
+    private static final String REGEX = "regex";
+
+    private RecipientRewriteTable mockedRecipientRewirtiteTable;
+    private RecipientRewriteTable testee;
+
+    @Before
+    public void setUp() throws Exception {
+        mockedRecipientRewirtiteTable = mock(RecipientRewriteTable.class);
+        testee = new HystrixRecipientRewriteTable(mockedRecipientRewirtiteTable);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = RecipientRewriteTableException.class)
+    public void recipientRewriteTableExceptionShouldBePropagated() throws  Exception {
+        when(mockedRecipientRewirtiteTable.getAllMappings()).thenThrow(RecipientRewriteTableException.class);
+        testee.getAllMappings();
+    }
+
+    @Test
+    public void addAddressMappingShouldCallUnderlyingRecipientRewriteTable() throws Exception {
+        testee.addAddressMapping(USER, DOMAIN, ADDRESS);
+        verify(mockedRecipientRewirtiteTable).addAddressMapping(USER, DOMAIN, ADDRESS);
+    }
+
+    @Test
+    public void addAliasDomainMappingShouldCallUnderlyingRecipientRewriteTable() throws Exception {
+        testee.addAliasDomainMapping(DOMAIN, REAL_DOMAIN);
+        verify(mockedRecipientRewirtiteTable).addAliasDomainMapping(DOMAIN, REAL_DOMAIN);
+    }
+
+    @Test
+    public void addErrorMappingShouldCallUnderlyingRecipientRewriteTable() throws Exception {
+        testee.addErrorMapping(USER, DOMAIN, ERROR);
+        verify(mockedRecipientRewirtiteTable).addErrorMapping(USER, DOMAIN, ERROR);
+    }
+
+    @Test
+    public void addMappingShouldCallUnderlyingRecipientRewriteTable() throws Exception {
+        testee.addMapping(USER, DOMAIN, MAPPING);
+        verify(mockedRecipientRewirtiteTable).addMapping(USER, DOMAIN, MAPPING);
+    }
+
+    @Test
+    public void addRegexMappingShouldCallUnderlyingRecipientRewriteTable() throws Exception {
+        testee.addRegexMapping(USER, DOMAIN, REGEX);
+        verify(mockedRecipientRewirtiteTable).addRegexMapping(USER, DOMAIN, REGEX);
+    }
+
+    @Test
+    public void getAllMappingsShouldCallUnderlyingRecipientRewriteTable() throws Exception {
+        testee.getAllMappings();
+        verify(mockedRecipientRewirtiteTable).getAllMappings();
+    }
+
+    @Test
+    public void getMappingsShouldCallUnderlyingRecipientRewriteTable() throws Exception {
+        testee.getMappings(USER, DOMAIN);
+        verify(mockedRecipientRewirtiteTable).getMappings(USER, DOMAIN);
+    }
+
+    @Test
+    public void getUserDomainMappingsShouldCallUnderlyingRecipientRewriteTable() throws Exception {
+        testee.getUserDomainMappings(USER, DOMAIN);
+        verify(mockedRecipientRewirtiteTable).getUserDomainMappings(USER, DOMAIN);
+    }
+
+    @Test
+    public void removeAddressMappingShouldCallUnderlyingRecipientRewriteTable() throws Exception {
+        testee.removeAddressMapping(USER, DOMAIN, ADDRESS);
+        verify(mockedRecipientRewirtiteTable).removeAddressMapping(USER, DOMAIN, ADDRESS);
+    }
+
+    @Test
+    public void removeAliasDomainMappingShouldCallUnderlyingRecipientRewriteTable() throws Exception {
+        testee.removeAliasDomainMapping(DOMAIN, REAL_DOMAIN);
+        verify(mockedRecipientRewirtiteTable).removeAliasDomainMapping(DOMAIN, REAL_DOMAIN);
+    }
+
+    @Test
+    public void removeErrorMappingShouldCallUnderlyingRecipientRewriteTable() throws Exception {
+        testee.removeErrorMapping(USER, DOMAIN, ERROR);
+        verify(mockedRecipientRewirtiteTable).removeErrorMapping(USER, DOMAIN, ERROR);
+    }
+
+    @Test
+    public void removeMappingShouldCallUnderlyingRecipientRewriteTable() throws Exception {
+        testee.removeMapping(USER, DOMAIN, MAPPING);
+        verify(mockedRecipientRewirtiteTable).removeMapping(USER, DOMAIN, MAPPING);
+    }
+
+    @Test
+    public void removeRegexMappingShouldCallUnderlyingRecipientRewriteTable() throws Exception {
+        testee.removeRegexMapping(USER, DOMAIN, REGEX);
+        verify(mockedRecipientRewirtiteTable).removeRegexMapping(USER, DOMAIN, REGEX);
+    }
+
+    @Test
+    public void getAllMappingsShouldFallback() throws Exception {
+        when(mockedRecipientRewirtiteTable.getAllMappings()).thenThrow(new RuntimeException());
+        assertThat(testee.getAllMappings()).isEmpty();
+    }
+
+    @Test
+    public void getMappingsShouldFallback() throws Exception {
+        when(mockedRecipientRewirtiteTable.getMappings(USER, DOMAIN)).thenThrow(new RuntimeException());
+        assertThat(testee.getMappings(USER, DOMAIN)).isEmpty();
+    }
+
+    @Test
+    public void getUserDomainMappingsShouldFallback() throws Exception {
+        when(mockedRecipientRewirtiteTable.getUserDomainMappings(USER, DOMAIN)).thenThrow(new RuntimeException());
+        assertThat(testee.getUserDomainMappings(USER, DOMAIN)).isEmpty();
+    }
+
+}

--- a/data/data-hystrix/src/test/java/org/apache/james/hystrix/users/HystrixUsersRepositoryTest.java
+++ b/data/data-hystrix/src/test/java/org/apache/james/hystrix/users/HystrixUsersRepositoryTest.java
@@ -1,0 +1,123 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.hystrix.users;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.james.user.api.UsersRepository;
+import org.apache.james.user.api.UsersRepositoryException;
+import org.apache.james.user.api.model.User;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HystrixUsersRepositoryTest {
+
+    private static final String PASSWORD = "password";
+    private static final String NAME = "name";
+
+    private UsersRepository mockedUsersRepository;
+    private UsersRepository testee;
+
+    @Before
+    public void setUp() throws Exception {
+        mockedUsersRepository = mock(UsersRepository.class);
+        testee = new HystrixUsersRepository(mockedUsersRepository);
+    }
+
+    @Test
+    public void countUsersShouldCallUnderlyingUsersRepository() throws Exception {
+        testee.countUsers();
+        verify(mockedUsersRepository).countUsers();
+    }
+
+    @Test
+    public void testShouldCallUnderlyingUsersRepository() throws Exception {
+        testee.test(NAME, PASSWORD);
+        verify(mockedUsersRepository).test(NAME, PASSWORD);
+    }
+
+    @Test
+    public void containsShouldCallUnderlyingUsersRepository() throws Exception {
+        testee.contains(NAME);
+        verify(mockedUsersRepository).contains(NAME);
+    }
+
+    @Test
+    public void getUserByNameShouldCallUnderlyingUsersRepository() throws Exception {
+        testee.getUserByName(NAME);
+        verify(mockedUsersRepository).getUserByName(NAME);
+    }
+
+    @Test
+    public void removeUserShouldCallUnderlyingUsersRepository() throws Exception {
+        testee.removeUser(NAME);
+        verify(mockedUsersRepository).removeUser(NAME);
+    }
+
+    @Test
+    public void listShouldCallUnderlyingUsersRepository() throws Exception {
+        testee.list();
+        verify(mockedUsersRepository).list();
+    }
+
+    @Test
+    public void updateUserShouldCallUnderlyingUsersRepository() throws Exception {
+        User user = new User() {
+            @Override
+            public String getUserName() {
+                return NAME;
+            }
+
+            @Override
+            public boolean verifyPassword(String pass) {
+                return false;
+            }
+
+            @Override
+            public boolean setPassword(String newPass) {
+                return false;
+            }
+        };
+        testee.updateUser(user);
+        verify(mockedUsersRepository).updateUser(user);
+    }
+
+    @Test
+    public void supportVirtualHostingShouldCallUnderlyingUsersRepository() throws Exception {
+        testee.supportVirtualHosting();
+        verify(mockedUsersRepository).supportVirtualHosting();
+    }
+
+    @Test
+    public void addUserShouldCallUnderlyingUsersRepository() throws Exception {
+        testee.addUser(NAME, PASSWORD);
+        verify(mockedUsersRepository).addUser(NAME, PASSWORD);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = UsersRepositoryException.class)
+    public void userRepositoryExceptionShouldBePropagated() throws Exception {
+        when(mockedUsersRepository.countUsers()).thenThrow(UsersRepositoryException.class);
+        testee.countUsers();
+    }
+
+}

--- a/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailetContext.java
+++ b/mailet/mailetcontainer-camel/src/main/java/org/apache/james/mailetcontainer/impl/JamesMailetContext.java
@@ -42,6 +42,7 @@ import org.apache.mailet.base.RFC2822Headers;
 import org.slf4j.Logger;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.mail.Address;
 import javax.mail.Message;
 import javax.mail.MessagingException;
@@ -90,12 +91,12 @@ public class JamesMailetContext implements MailetContext, LogEnabled, Configurab
     }
 
     @Inject
-    public void setUsersRepository(UsersRepository localusers) {
+    public void setUsersRepository(@Named("usersrepository") UsersRepository localusers) {
         this.localusers = localusers;
     }
 
     @Inject
-    public void setDomainList(DomainList domains) {
+    public void setDomainList(@Named("domainlist") DomainList domains) {
         this.domains = domains;
     }
 

--- a/mailet/mailets/src/main/java/org/apache/james/transport/mailets/AbstractRecipientRewriteTable.java
+++ b/mailet/mailets/src/main/java/org/apache/james/transport/mailets/AbstractRecipientRewriteTable.java
@@ -29,6 +29,7 @@ import java.util.StringTokenizer;
 import java.util.regex.PatternSyntaxException;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.mail.MessagingException;
 import javax.mail.internet.ParseException;
 
@@ -60,7 +61,7 @@ public abstract class AbstractRecipientRewriteTable extends GenericMailet {
     }
 
     @Inject
-    public void setDomainList(DomainList domainList) {
+    public void setDomainList(@Named("domainlist") DomainList domainList) {
         this.domainList = domainList;
     }
 

--- a/mailet/mailets/src/main/java/org/apache/james/transport/mailets/AbstractRecipientRewriteTableMailet.java
+++ b/mailet/mailets/src/main/java/org/apache/james/transport/mailets/AbstractRecipientRewriteTableMailet.java
@@ -26,6 +26,7 @@ import java.util.LinkedList;
 import java.util.Vector;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
@@ -45,7 +46,7 @@ public abstract class AbstractRecipientRewriteTableMailet extends GenericMailet 
     private DomainList domainList;
 
     @Inject
-    public void setDomainList(DomainList domainList) {
+    public void setDomainList(@Named("domainlist") DomainList domainList) {
         this.domainList = domainList;
     }
 

--- a/mailet/mailets/src/main/java/org/apache/james/transport/mailets/FromRepository.java
+++ b/mailet/mailets/src/main/java/org/apache/james/transport/mailets/FromRepository.java
@@ -22,6 +22,7 @@ package org.apache.james.transport.mailets;
 import java.util.Iterator;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.mail.MessagingException;
 
 import org.apache.james.lifecycle.api.LifecycleUtil;
@@ -58,7 +59,7 @@ public class FromRepository extends GenericMailet {
     private MailRepositoryStore mailStore;
 
     @Inject
-    public void setStore(MailRepositoryStore mailStore) {
+    public void setStore(@Named("mailrepositorystore") MailRepositoryStore mailStore) {
         this.mailStore = mailStore;
     }
 

--- a/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTable.java
+++ b/mailet/mailets/src/main/java/org/apache/james/transport/mailets/RecipientRewriteTable.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
@@ -44,7 +45,7 @@ public class RecipientRewriteTable extends AbstractRecipientRewriteTableMailet {
      *            the vutStore to set, possibly null
      */
     @Inject
-    public final void setRecipientRewriteTable(org.apache.james.rrt.api.RecipientRewriteTable vut) {
+    public final void setRecipientRewriteTable(@Named("recipientrewritetable") org.apache.james.rrt.api.RecipientRewriteTable vut) {
         this.vut = vut;
     }
 

--- a/mailet/mailets/src/main/java/org/apache/james/transport/mailets/ToRecipientFolder.java
+++ b/mailet/mailets/src/main/java/org/apache/james/transport/mailets/ToRecipientFolder.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Iterator;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.mail.MessagingException;
 
 import org.apache.commons.collections.iterators.IteratorChain;
@@ -53,9 +54,11 @@ import org.apache.mailet.base.GenericMailet;
 public class ToRecipientFolder extends GenericMailet {
 
     @Inject
+    @Named("mailboxmanager")
     private MailboxManager mailboxManager;
     
     @Inject
+    @Named("usersrepository")
     private UsersRepository usersRepository;
     
     @Inject

--- a/mailet/mailets/src/main/java/org/apache/james/transport/mailets/UsersRepositoryAliasingForwarding.java
+++ b/mailet/mailets/src/main/java/org/apache/james/transport/mailets/UsersRepositoryAliasingForwarding.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
@@ -66,7 +67,7 @@ public class UsersRepositoryAliasingForwarding extends AbstractRecipientRewriteT
     }
 
     @Inject
-    public void setUsersRepository(UsersRepository usersRepository) {
+    public void setUsersRepository(@Named("usersrepository") UsersRepository usersRepository) {
         this.usersRepository = usersRepository;
     }
 

--- a/mailet/mailets/src/main/java/org/apache/james/transport/mailets/WhiteListManager.java
+++ b/mailet/mailets/src/main/java/org/apache/james/transport/mailets/WhiteListManager.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.StringTokenizer;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.mail.Message;
 import javax.mail.MessagingException;
 import javax.mail.Session;
@@ -165,7 +166,7 @@ public class WhiteListManager extends GenericMailet {
     }
 
     @Inject
-    public void setUsersRepository(UsersRepository localusers) {
+    public void setUsersRepository(@Named("usersrepository") UsersRepository localusers) {
         this.localusers = localusers;
     }
 

--- a/mailet/mailets/src/main/java/org/apache/james/transport/matchers/AbstractSQLWhitelistMatcher.java
+++ b/mailet/mailets/src/main/java/org/apache/james/transport/matchers/AbstractSQLWhitelistMatcher.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.StringTokenizer;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.mail.MessagingException;
 import javax.sql.DataSource;
 
@@ -63,7 +64,7 @@ public abstract class AbstractSQLWhitelistMatcher extends GenericMatcher {
     }
 
     @Inject
-    public void setUsersRepository(UsersRepository localusers) {
+    public void setUsersRepository(@Named("usersrepository") UsersRepository localusers) {
         this.localusers = localusers;
     }
 

--- a/mailet/mailets/src/main/java/org/apache/james/transport/matchers/AbstractStorageQuota.java
+++ b/mailet/mailets/src/main/java/org/apache/james/transport/matchers/AbstractStorageQuota.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Locale;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.mail.MessagingException;
 
 import org.apache.james.mailbox.MailboxManager;
@@ -67,12 +68,12 @@ abstract public class AbstractStorageQuota extends AbstractQuotaMatcher {
     private MailboxManager manager;
 
     @Inject
-    public void setMailboxManager(MailboxManager manager) {
+    public void setMailboxManager(@Named("mailboxmanager")MailboxManager manager) {
         this.manager = manager;
     }
 
     @Inject
-    public void setUsersRepository(UsersRepository localUsers) {
+    public void setUsersRepository(@Named("usersrepository") UsersRepository localUsers) {
         this.localUsers = localUsers;
     }
 

--- a/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsOverQuota.java
+++ b/mailet/mailets/src/main/java/org/apache/james/transport/matchers/IsOverQuota.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.mail.MessagingException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,12 +34,12 @@ public class IsOverQuota extends GenericMatcher {
     }
 
     @Inject
-    public void setQuotaManager(QuotaManager quotaManager) {
+    public void setQuotaManager(@Named("quotaManager") QuotaManager quotaManager) {
         this.quotaManager = quotaManager;
     }
 
     @Inject
-    public void setMailboxManager(MailboxManager mailboxManager) {
+    public void setMailboxManager(@Named("mailboxmanager") MailboxManager mailboxManager) {
         this.mailboxManager = mailboxManager;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.james</groupId>
+                <artifactId>james-server-data-hystrix</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.james</groupId>
                 <artifactId>james-server-data-file</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <module>data/data-file</module>
         <module>data/data-ldap</module>
         <module>data/data-hbase</module>
+        <module>data/data-hystrix</module>
 
         <module>protocols/fetchmail</module>
         <module>protocols/protocols-imap4</module>
@@ -1096,6 +1097,17 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.netflix.hystrix</groupId>
+                <artifactId>hystrix-core</artifactId>
+                <version>1.4.14</version>
+            </dependency>
+            <dependency>
+                <groupId>com.netflix.rxjava</groupId>
+                <artifactId>rxjava-core</artifactId>
+                <version>0.20.7</version>
             </dependency>
 
             <!-- OSGI dependencies -->

--- a/protocols/fetchmail/src/main/java/org/apache/james/fetchmail/FetchScheduler.java
+++ b/protocols/fetchmail/src/main/java/org/apache/james/fetchmail/FetchScheduler.java
@@ -29,6 +29,7 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.annotation.Resource;
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
@@ -83,13 +84,13 @@ public class FetchScheduler implements FetchSchedulerMBean, LogEnabled, Configur
 
     @Inject
     @Resource
-    public void setUsersRepository(UsersRepository urepos) {
+    public void setUsersRepository(@Named("usersrepository") UsersRepository urepos) {
         this.urepos = urepos;
     }
 
     @Inject
     @Resource
-    public void setDomainList(DomainList domainList) {
+    public void setDomainList(@Named("domainlist") DomainList domainList) {
         this.domainList = domainList;
     }
 

--- a/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptHandler.java
+++ b/protocols/protocols-smtp/src/main/java/org/apache/james/smtpserver/fastfail/ValidRcptHandler.java
@@ -77,7 +77,7 @@ public class ValidRcptHandler extends AbstractValidRcptHandler implements Initia
      *            the tableStore to set
      */
     @Inject
-    public final void setRecipientRewriteTable(RecipientRewriteTable vut) {
+    public final void setRecipientRewriteTable(@Named("recipientrewritetable") RecipientRewriteTable vut) {
         this.vut = vut;
     }
 

--- a/src/site/xdoc/config-domainlist.xml
+++ b/src/site/xdoc/config-domainlist.xml
@@ -56,6 +56,20 @@ In most cases this will be necessary. By default, the domainname 'localhost' is 
 <p>Warning: If you are using fetchmail it is important to include the 
 fetched domains in the server name list to prevent looping.</p>
 
+      <subsection name="Hystrix integration">
+      <p>
+          Finally, you will notice the possibility to enable Hystrix wrapping for your Domain List.
+      </p>
+      <p>
+          To do so, you need to switch enableHystrix to "true".
+      </p>
+      <p>
+          Hystrix is a Netflix library. It allows you to better handle failures in a (distributed) system. It provides fallback and a circuit breaker.
+          This means your backend will not be to much overloaded as circuits will be open before.
+          In addition Hystrix provides live metrics, and support live configuration.
+      </p>
+      </subsection>
+
   </section>
 
 </body>

--- a/src/site/xdoc/config-mailbox.xml
+++ b/src/site/xdoc/config-mailbox.xml
@@ -38,6 +38,20 @@
         <dd>Supported providers are: jpa (default), jcr, maildir, memory. Be aware that maildir will only work on unix like operation systems!</dd>
       </dl>
 
+    <subsection name="Hystrix integration">
+      <p>
+        Finally, you will notice the possibility to enable Hystrix wrapping for your MailboxManager.
+      </p>
+      <p>
+        To do so, you need to switch enableHystrix to "true".
+      </p>
+      <p>
+        Hystrix is a Netflix library. It allows you to better handle failures in a (distributed) system. It provides fallback and a circuit breaker.
+        This means your backend will not be to much overloaded as circuits will be open before.
+        In addition Hystrix provides live metrics, and support live configuration.
+      </p>
+    </subsection>
+
   </section>
 
 </body>

--- a/src/site/xdoc/config-mailrepositorystore.xml
+++ b/src/site/xdoc/config-mailrepositorystore.xml
@@ -100,6 +100,20 @@
       <p>If you enable this you need to make sure that embedded Jackrabbit instance is started as well. Check the container configuration</p>
         
     </subsection>
+
+    <subsection name="Hystrix integration">
+    <p>
+      Finally, you will notice the possibility to enable Hystrix wrapping for each one of these Mail Repositories.
+    </p>
+    <p>
+      To do so, you need to switch enableHystrix to "true".
+    </p>
+    <p>
+      Hystrix is a Netflix library. It allows you to better handle failures in a (distributed) system. It provides fallback and a circuit breaker.
+      This means your backend will not be to much overloaded as circuits will be open before.
+      In addition Hystrix provides live metrics, and support live configuration.
+    </p>
+    </subsection>
   
   </section>
 

--- a/src/site/xdoc/config-quota.xml
+++ b/src/site/xdoc/config-quota.xml
@@ -90,6 +90,14 @@
       </ul>
     </p>
 
+    <subsection name="Hystrix integration">
+    <p>
+      Finally, you will notice the possibility to enable Hystrix wrapping for your MaxQuotaManager and your CurrentQuotaManager.
+      Hystrix is a Netflix library. It allows you to better handle failures in a (distributed) system. It provides fallback and a circuit breaker.
+      This means your backend will not be to much overloaded as circuits will be open before. In addition Hystrix provides live metrics, and support live configuration.
+    </p>
+    </subsection>
+
   </section>
 
 </body>

--- a/src/site/xdoc/config-recipientrewritetable.xml
+++ b/src/site/xdoc/config-recipientrewritetable.xml
@@ -78,6 +78,20 @@
 
     </subsection>
 
+      <subsection name="Hystrix integration">
+          <p>
+              Finally, you will notice the possibility to enable Hystrix wrapping for your Recipient Rewrite Table.
+          </p>
+          <p>
+              To do so, you need to switch enableHystrix to "true".
+          </p>
+          <p>
+              Hystrix is a Netflix library. It allows you to better handle failures in a (distributed) system. It provides fallback and a circuit breaker.
+              This means your backend will not be to much overloaded as circuits will be open before.
+              In addition Hystrix provides live metrics, and support live configuration.
+          </p>
+      </subsection>
+
     </section>
 
 </body>

--- a/src/site/xdoc/config-users.xml
+++ b/src/site/xdoc/config-users.xml
@@ -231,6 +231,20 @@
 -->    
      </subsection>
 
+      <subsection name="Hystrix integration">
+          <p>
+              Finally, you will notice the possibility to enable Hystrix wrapping for your Domain List.
+          </p>
+          <p>
+              To do so, you need to switch enableHystrix to "true".
+          </p>
+          <p>
+              Hystrix is a Netflix library. It allows you to better handle failures in a (distributed) system. It provides fallback and a circuit breaker.
+              This means your backend will not be to much overloaded as circuits will be open before.
+              In addition Hystrix provides live metrics, and support live configuration.
+          </p>
+      </subsection>
+
   </section>
 
 </body>


### PR DESCRIPTION
This PRs : 
 - Introduces basic Hystrix wrapping for : 
       - MailRepository store with no fallback
       - UsersRepository with no fallback
       - DomainList ( with fallback mode to default domain )
       - RecipientRewriteTable ( with FallBackMode to no rewrite )

( With these conditions SMTP mails gets received even if storage backend is unavailable )

In addition to this, it handles configuration issues for these components and those from MAILBOX-253 ( one line configuration for each component ), and documentation modifications.